### PR TITLE
 feat: add shouldValidIgnoreRegisterCount prop

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -353,6 +353,14 @@ switch (trigger) {
 > The structure object being used internally for values. You may wish to use
 > `deepEqual` from the structure.
 
+#### `shouldValidIgnoreRegisterCount : boolean` [optional]
+
+> should ignore the filter of count while validate
+> Defaults to
+> `false`.
+
+多个子表单时 搭配 `forceUnregisterOnUnmount: false` 使用：表单会校验所有字段，以避免 unregister 被忽略的问题。
+
 #### `touchOnBlur : boolean` [optional]
 
 > marks fields as `touched` when the blur action is fired. Defaults to `true`.

--- a/examples/wizard/src/WizardForm.js
+++ b/examples/wizard/src/WizardForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { submit, destroy } from 'caicloud-redux-form'
 import PropTypes from 'prop-types'
 import WizardFormFirstPage from './WizardFormFirstPage'
 import WizardFormSecondPage from './WizardFormSecondPage'
@@ -13,12 +14,22 @@ class WizardForm extends Component {
       page: 1
     }
   }
+
+  // destroy form will unmount
+  componentWillUnmount() {
+    this.props.dispatch(destroy('wizard'))
+  }
+
   nextPage() {
     this.setState({ page: this.state.page + 1 })
   }
 
   previousPage() {
     this.setState({ page: this.state.page - 1 })
+  }
+
+  remoteSubmit() {
+    this.props.dispatch(submit('wizard'))
   }
 
   render() {
@@ -39,6 +50,9 @@ class WizardForm extends Component {
             onSubmit={onSubmit}
           />
         )}
+        <button onClick={this.previousPage}>Pre</button>
+        <button onClick={this.nextPage}>Next</button>
+        <button onClick={this.remoteSubmit}>Submit</button>
       </div>
     )
   }

--- a/examples/wizard/src/WizardFormFirstPage.js
+++ b/examples/wizard/src/WizardFormFirstPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Field, reduxForm } from 'redux-form'
+import { Field, reduxForm } from 'caicloud-redux-form'
 import validate from './validate'
 import renderField from './renderField'
 
@@ -19,11 +19,6 @@ const WizardFormFirstPage = props => {
         component={renderField}
         label="Last Name"
       />
-      <div>
-        <button type="submit" className="next">
-          Next
-        </button>
-      </div>
     </form>
   )
 }
@@ -31,6 +26,7 @@ const WizardFormFirstPage = props => {
 export default reduxForm({
   form: 'wizard', // <------ same form name
   destroyOnUnmount: false, // <------ preserve form data
-  forceUnregisterOnUnmount: true, // <------ unregister fields on unmount
+  forceUnregisterOnUnmount: false, // <------ unregister fields on unmount
+  shouldValidIgnoreRegisterCount: true,
   validate
 })(WizardFormFirstPage)

--- a/examples/wizard/src/WizardFormSecondPage.js
+++ b/examples/wizard/src/WizardFormSecondPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Field, reduxForm } from 'redux-form'
+import { Field, reduxForm } from 'caicloud-redux-form'
 import validate from './validate'
 import renderField from './renderField'
 
@@ -15,21 +15,11 @@ const WizardFormSecondPage = props => {
         <label>Sex</label>
         <div>
           <label>
-            <Field
-              name="sex"
-              component="input"
-              type="radio"
-              value="male"
-            />{' '}
+            <Field name="sex" component="input" type="radio" value="male" />{' '}
             Male
           </label>
           <label>
-            <Field
-              name="sex"
-              component="input"
-              type="radio"
-              value="female"
-            />{' '}
+            <Field name="sex" component="input" type="radio" value="female" />{' '}
             Female
           </label>
           <Field name="sex" component={renderError} />
@@ -49,7 +39,7 @@ const WizardFormSecondPage = props => {
 
 export default reduxForm({
   form: 'wizard', //Form name is same
-  destroyOnUnmount: false,
-  forceUnregisterOnUnmount: true, // <------ unregister fields on unmount
+  forceUnregisterOnUnmount: false, // <------ unregister fields on unmount
+  shouldValidIgnoreRegisterCount: true,
   validate
 })(WizardFormSecondPage)

--- a/examples/wizard/src/WizardFormThirdPage.js
+++ b/examples/wizard/src/WizardFormThirdPage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Field, reduxForm } from 'redux-form'
+import { Field, reduxForm } from 'caicloud-redux-form'
 import validate from './validate'
 const colors = ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet']
 

--- a/examples/wizard/src/index.js
+++ b/examples/wizard/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore, combineReducers } from 'redux'
-import { reducer as reduxFormReducer } from 'redux-form'
+import { reducer as reduxFormReducer } from 'caicloud-redux-form'
 import {
   App,
   Code,
@@ -67,7 +67,7 @@ let render = () => {
 
         <h2>Form</h2>
 
-        <WizardForm onSubmit={showResults} />
+        <WizardForm onSubmit={showResults} dispatch={store.dispatch} />
 
         <Values form="wizard" />
 

--- a/examples/wizard/src/reducer.js
+++ b/examples/wizard/src/reducer.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux'
-import { reducer as reduxFormReducer } from 'redux-form'
+import { reducer as reduxFormReducer } from 'caicloud-redux-form'
 
 const reducer = combineReducers({
   form: reduxFormReducer

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -844,6 +844,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
             setSubmitFailed,
             setSubmitSucceeded,
             shouldAsyncValidate,
+            shouldValidIgnoreRegisterCount,
             shouldValidate,
             shouldError,
             shouldWarn,
@@ -940,7 +941,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
             getFormState,
             initialValues,
             enableReinitialize,
-            keepDirtyOnReinitialize
+            keepDirtyOnReinitialize,
+            shouldValidIgnoreRegisterCount
           } = props
           const formState = getIn(getFormState(state) || empty, form) || empty
           const stateInitial = getIn(formState, 'initial')
@@ -970,8 +972,18 @@ const createReduxForm = (structure: Structure<*, *>) => {
           const syncErrors = getIn(formState, 'syncErrors') || {}
           const syncWarnings = getIn(formState, 'syncWarnings') || {}
           const registeredFields = getIn(formState, 'registeredFields')
-          const valid = isValid(form, getFormState, false)(state)
-          const validExceptSubmit = isValid(form, getFormState, true)(state)
+          const valid = isValid(
+            form,
+            getFormState,
+            false,
+            shouldValidIgnoreRegisterCount
+          )(state)
+          const validExceptSubmit = isValid(
+            form,
+            getFormState,
+            true,
+            shouldValidIgnoreRegisterCount
+          )(state)
           const anyTouched = !!getIn(formState, 'anyTouched')
           const submitting = !!getIn(formState, 'submitting')
           const submitFailed = !!getIn(formState, 'submitFailed')

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -9,7 +9,8 @@ const createIsValid = (structure: Structure<*, *>) => {
   return (
     form: string,
     getFormState: ?GetFormState,
-    ignoreSubmitErrors: ?boolean = false
+    ignoreSubmitErrors: ?boolean = false,
+    shouldValidIgnoreRegisterCount: ?boolean = false
   ): IsValidInterface => (state: any) => {
     const nonNullGetFormState: GetFormState =
       getFormState || (state => getIn(state, 'form'))
@@ -38,16 +39,20 @@ const createIsValid = (structure: Structure<*, *>) => {
       return true
     }
 
-    return !keys(registeredFields)
-      .filter(name => getIn(registeredFields, `['${name}'].count`) > 0)
-      .some(name =>
-        hasError(
-          getIn(registeredFields, `['${name}']`),
-          syncErrors,
-          asyncErrors,
-          submitErrors
+    const shouldValidFieldNames = shouldValidIgnoreRegisterCount
+      ? keys(registeredFields)
+      : keys(registeredFields).filter(
+          name => getIn(registeredFields, `['${name}'].count`) > 0
         )
+
+    return !shouldValidFieldNames.some(name =>
+      hasError(
+        getIn(registeredFields, `['${name}']`),
+        syncErrors,
+        asyncErrors,
+        submitErrors
       )
+    )
   }
 }
 


### PR DESCRIPTION
增加 shouldValidIgnoreRegisterCount 选项，支持多表单时校验注册的所有字段

- isValid 中过滤 `count <= 0`  的 fields，此选项会忽略掉 filter 以校验全部 fields