### PR TITLE
fix(initialize): Fix for double INITIALIZE happening on first mount 

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -539,7 +539,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         componentDidMount() {
           if (!isHotReloading()) {
-            this.initIfNeeded()
+            this.initIfNeeded(this.props)
             this.validateIfNeeded()
             this.warnIfNeeded()
           }

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -240,6 +240,7 @@ export type Props = {
   setSubmitSucceeded: SetSubmitSucceededAction,
   shouldAsyncValidate: ShouldAsyncValidateFunction,
   shouldValidate: ShouldValidateFunction,
+  shouldValidIgnoreRegisterCount: boolean,
   shouldError: ShouldErrorFunction,
   shouldWarn: ShouldWarnFunction,
   startAsyncValidation: StartAsyncValidationAction,


### PR DESCRIPTION
* fix an issue where INITIALIZE action is fired twice clearing change actions that happen when a form mounts

* undo auto-formatting changes

bug detail: https://github.com/erikras/redux-form/issues/3690