### PR TITLE
fix(blurReducer): 删除 blur 写入 store 的逻辑

### DIFF
--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -197,9 +197,10 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       const initial = getIn(result, `initial.${field}`)
       if (initial === undefined && payload === '') {
         result = deleteInWithCleanUp(result, `values.${field}`)
-      } else if (payload !== undefined) {
-        result = setIn(result, `values.${field}`, payload)
       }
+      // else if (payload !== undefined) {
+      //   result = setIn(result, `values.${field}`, payload)
+      // }
       if (field === getIn(result, 'active')) {
         result = deleteIn(result, 'active')
       }


### PR DESCRIPTION
由于 redux-form 中的表单元素 blur 事件会向 store 中写值, 而在 InputNumber 期望写入 Number 但是 Blur 的 reducer 会写入 String
删除写入逻辑