### PR TITLE
fix(blurReducer): 删除 blur 写入 store 的逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caicloud/redux-form",
-  "version": "1.0.2-alpha1",
+  "version": "1.0.3-alpha.1",
   "description": "A higher order component decorator for forms using Redux and React",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caicloud/redux-form",
-  "version": "1.0.2",
+  "version": "1.0.2-alpha1",
   "description": "A higher order component decorator for forms using Redux and React",
   "main": "./lib/index.js",
   "module": "./es/index.js",

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -199,6 +199,7 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       if (initial === undefined && payload === '') {
         result = deleteInWithCleanUp(result, `values.${field}`)
       }
+      // Prevent blur reducer sets value in store.
       // else if (payload !== undefined) {
       //   result = setIn(result, `values.${field}`, payload)
       // }

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -198,9 +198,10 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       const initial = getIn(result, `initial.${field}`)
       if (initial === undefined && payload === '') {
         result = deleteInWithCleanUp(result, `values.${field}`)
-      } else if (payload !== undefined) {
-        result = setIn(result, `values.${field}`, payload)
       }
+      // else if (payload !== undefined) {
+      //   result = setIn(result, `values.${field}`, payload)
+      // }
       if (field === getIn(result, 'active')) {
         result = deleteIn(result, 'active')
       }


### PR DESCRIPTION
```release-note
删除 blur 写入 store 的逻辑
```

由于 redux-form 中的表单元素 blur 事件会向 store 中写值, 而在 InputNumber 期望写入 Number 但是 Blur 的 reducer 会写入 String
删除写入逻辑